### PR TITLE
feat: update with mise support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,12 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 2
+indent_style = tab
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,12 @@
-name: Build
+name: asdf
 
 on:
   push:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: 0 0 * * 5
 
 jobs:
   plugin_test:
@@ -12,6 +14,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v3
         with:
           command: xcodes --help
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: lint
 
 on:
   push:
@@ -7,30 +7,18 @@ on:
   pull_request:
 
 jobs:
-  shellcheck:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+      - uses: asdf-vm/actions/install@v4
+      - run: scripts/lint.bash
 
-      - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v1
-
-      - name: Run ShellCheck
-        run: scripts/shellcheck.bash
-
-  shellfmt:
+  actionlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v1
-
-      - name: List file to shfmt
-        run: shfmt -f .
-
-      - name: Run shfmt
-        run: scripts/shfmt.bash
-
+      - uses: actions/checkout@v6
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.6.23
+        with:
+          args: -color

--- a/.github/workflows/test-mise.yml
+++ b/.github/workflows/test-mise.yml
@@ -1,0 +1,28 @@
+name: mise
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: 0 0 * * 5
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  test:
+    name: mise test
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Mise
+        uses: jdx/mise-action@v3
+        with:
+          install: false
+
+      - run: mise exec asdf:https://github.com/younke/asdf-xcodes@latest -- xcodes --help

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-shellcheck 0.7.2
-shfmt 3.3.0
+shellcheck 0.9.0
+shfmt 3.6.0

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 <div align="center">
 
-# asdf-xcodes [![Build](https://github.com/younke/asdf-xcodes/actions/workflows/build.yml/badge.svg)](https://github.com/younke/asdf-xcodes/actions/workflows/build.yml) [![Lint](https://github.com/younke/asdf-xcodes/actions/workflows/lint.yml/badge.svg)](https://github.com/younke/asdf-xcodes/actions/workflows/lint.yml)
+# asdf-xcodes
 
+[![Build](https://github.com/younke/asdf-xcodes/actions/workflows/build.yml/badge.svg)](https://github.com/younke/asdf-xcodes/actions/workflows/build.yml)
+[![Lint](https://github.com/younke/asdf-xcodes/actions/workflows/lint.yml/badge.svg)](https://github.com/younke/asdf-xcodes/actions/workflows/lint.yml)
+[![Mise](https://github.com/younke/asdf-xcodes/actions/workflows/test-mise.yml/badge.svg)](https://github.com/younke/asdf-xcodes/actions/workflows/test-mise.yml)
 
-[xcodes](https://github.com/RobotsAndPencils/xcodes) plugin for the [asdf version manager](https://asdf-vm.com).
+[xcodes](https://github.com/XcodesOrg/xcodes) plugin for the [asdf version manager](https://asdf-vm.com).
 
 </div>
 

--- a/bin/download
+++ b/bin/download
@@ -5,18 +5,30 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
+release_file_base="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION"
 
-# Download zip file to the download directory
-download_release "$ASDF_INSTALL_VERSION" "$release_file"
+# Download release archive (sets RELEASE_EXT to tar.gz or zip)
+download_release "$ASDF_INSTALL_VERSION" "$release_file_base"
 
-#  Extract contents of zip file into the download directory
-unzip "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+release_file="$release_file_base.$RELEASE_EXT"
 
-# Remove the zip file since we don't need to keep it
+# Extract contents based on archive type
+if [[ "$RELEASE_EXT" == "tar.gz" ]]; then
+	# Architecture-specific tar.gz has nested structure: xcodes/VERSION/bin/xcodes
+	tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+	# Move binary from nested structure to download path root
+	mv "$ASDF_DOWNLOAD_PATH/$TOOL_NAME/$ASDF_INSTALL_VERSION/bin/$TOOL_NAME" "$ASDF_DOWNLOAD_PATH/$TOOL_NAME.bin"
+	rm -rf "${ASDF_DOWNLOAD_PATH:?}/${TOOL_NAME:?}"
+	mv "$ASDF_DOWNLOAD_PATH/$TOOL_NAME.bin" "$ASDF_DOWNLOAD_PATH/$TOOL_NAME"
+else
+	# Universal zip has flat structure: xcodes at root
+	unzip -q "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+fi
+
+# Remove the archive since we don't need to keep it
 rm "$release_file"

--- a/bin/install
+++ b/bin/install
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=./lib/utils.bash
+. "${plugin_dir}/lib/utils.bash"
+
+curl_opts=(-sI)
+
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_TOKEN")
+fi
+
+# curl of REPO/releases/latest is expected to be a 302 to another URL
+# when no releases redirect_url="REPO/releases"
+# when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
+redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
+version=
+printf "redirect url: %s\n" "$redirect_url" >&2
+if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
+	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
+else
+	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
+fi
+
+printf "%s\n" "$version"

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-list_all_versions | sort_versions | xargs echo
+list_all_versions | grep -v '^0\.' | sort_versions | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,67 +2,105 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/RobotsAndPencils/xcodes"
+GH_REPO="https://github.com/XcodesOrg/xcodes"
 TOOL_NAME="xcodes"
 TOOL_TEST="xcodes --help"
 
 fail() {
-  echo -e "asdf-$TOOL_NAME: $*"
-  exit 1
+	echo -e "asdf-$TOOL_NAME: $*"
+	exit 1
 }
 
 curl_opts=(-fsSL)
 
-if [ -n "${GITHUB_API_TOKEN:-}" ]; then
-  curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_TOKEN")
 fi
 
 sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
+get_arch() {
+	local arch
+	arch=$(uname -m)
+	case "$arch" in
+	arm64 | aarch64) echo "arm64" ;;
+	x86_64) echo "i386" ;;
+	*) fail "Unsupported architecture: $arch" ;;
+	esac
 }
 
 list_github_tags() {
-  git ls-remote --tags --refs "$GH_REPO" |
-    grep -o 'refs/tags/.*' | cut -d/ -f3- |
-    sed 's/^v//'
+	git ls-remote --tags --refs "$GH_REPO" |
+		grep -o 'refs/tags/.*' | cut -d/ -f3- |
+		sed 's/^v//'
 }
 
 list_all_versions() {
-  list_github_tags
+	list_github_tags
 }
 
+get_arch_url() {
+	local version="$1"
+	local arch
+	arch=$(get_arch)
+	echo "$GH_REPO/releases/download/${version}/${TOOL_NAME}-${version}.macos.${arch}.tar.gz"
+}
+
+get_zip_url() {
+	local version="$1"
+	echo "$GH_REPO/releases/download/${version}/${TOOL_NAME}.zip"
+}
+
+# Check if URL exists (returns 0 if exists, 1 otherwise)
+url_exists() {
+	curl -sfIL "$1" >/dev/null 2>&1
+}
+
+# Download release, trying architecture-specific binary first, falling back to zip
+# Sets RELEASE_EXT to the extension of the downloaded file (used by caller)
+# shellcheck disable=SC2034
 download_release() {
-  local version filename url
-  version="$1"
-  filename="$2"
+	local version="$1"
+	local filename_base="$2"
+	local arch_url zip_url
 
-  url="$GH_REPO/releases/download/${version}/${TOOL_NAME}.zip"
+	arch_url=$(get_arch_url "$version")
+	zip_url=$(get_zip_url "$version")
 
-  echo "* Downloading $TOOL_NAME release $version..."
-  curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+	echo "* Downloading $TOOL_NAME release $version..."
+
+	if url_exists "$arch_url"; then
+		RELEASE_EXT="tar.gz"
+		curl "${curl_opts[@]}" -o "${filename_base}.tar.gz" "$arch_url" || fail "Could not download $arch_url"
+	else
+		RELEASE_EXT="zip"
+		curl "${curl_opts[@]}" -o "${filename_base}.zip" "$zip_url" || fail "Could not download $zip_url"
+	fi
 }
 
 install_version() {
-  local install_type="$1"
-  local version="$2"
-  local install_path="${3%/bin}/bin"
+	local install_type="$1"
+	local version="$2"
+	local install_path="${3%/bin}/bin"
 
-  if [ "$install_type" != "version" ]; then
-    fail "asdf-$TOOL_NAME supports release installs only"
-  fi
+	if [ "$install_type" != "version" ]; then
+		fail "asdf-$TOOL_NAME supports release installs only"
+	fi
 
-  (
-    mkdir -p "$install_path"
-    cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
+	(
+		mkdir -p "$install_path"
+		cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
 
-    local tool_cmd
-    tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
-    test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."
+		local tool_cmd
+		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
+		test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."
 
-    echo "$TOOL_NAME $version installation was successful!"
-  ) || (
-    rm -rf "$install_path"
-    fail "An error occurred while installing $TOOL_NAME $version."
-  )
+		echo "$TOOL_NAME $version installation was successful!"
+	) || (
+		rm -rf "$install_path"
+		fail "An error occurred while installing $TOOL_NAME $version."
+	)
 }

--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+shfmt --language-dialect bash --write \
+	./**/*

--- a/scripts/lint.bash
+++ b/scripts/lint.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+shellcheck --shell=bash --external-sources \
+	bin/* --source-path=lib/ \
+	lib/* \
+	scripts/*
+
+shfmt --language-dialect bash --diff \
+	./**/*

--- a/scripts/shellcheck.bash
+++ b/scripts/shellcheck.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-exec shellcheck -s bash -x \
-  bin/* -P lib/

--- a/scripts/shfmt.bash
+++ b/scripts/shfmt.bash
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-exec shfmt -d .


### PR DESCRIPTION
## Summary

- Add mise compatibility with new CI workflow for testing mise integration
- Update xcodes repo reference from `RobotsAndPencils/xcodes` to `XcodesOrg/xcodes`
- Add architecture-specific binary support (arm64/x86_64) with fallback to universal zip
- Add `bin/latest-stable` script for better version resolution
- Update GitHub Actions to v3/v4/v6 and add actionlint job
- Upgrade tooling: shellcheck 0.9.0, shfmt 3.6.0
- Consolidate lint scripts into single `scripts/lint.bash`
- Switch from `GITHUB_API_TOKEN` to `GITHUB_TOKEN` environment variable
- Filter out 0.x versions from `list-all` output
- Update code style to use tabs (matching shfmt defaults)
